### PR TITLE
Call redis.expire with 'self.expires' instead of 'expires'

### DIFF
--- a/retools/lock.py
+++ b/retools/lock.py
@@ -55,7 +55,7 @@ class Lock(object):
             if redis.setnx(self.key, expires):
                 # We gained the lock; enter critical section
                 self.start_time = time.time()
-                redis.expire(self.key, int(expires))
+                redis.expire(self.key, int(self.expires))
                 return
 
             current_value = redis.get(self.key)
@@ -64,7 +64,7 @@ class Lock(object):
             if current_value and float(current_value) < time.time() and \
                redis.getset(self.key, expires) == current_value:
                 self.start_time = time.time()
-                redis.expire(self.key, int(expires))
+                redis.expire(self.key, int(self.expires))
                 return
 
             timeout -= 1


### PR DESCRIPTION
Call redis.expire with 'self.expires' (the delta) - not 'expires' - a large number.

It might make sense to rename one of the 'expires' to reflect the fact that one is a delta and one is a point in time.
