### PR TITLE
Limiter functionality.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,8 @@ language: python
 python:
   - "2.6"
   - "2.7"
-install: python setup.py develop
+install: 
+  - sudo apt-get install redis-server
+  - redis-server &
+  - python setup.py develop
 script: python setup.py nosetests

--- a/docs/api/limiter.rst
+++ b/docs/api/limiter.rst
@@ -1,0 +1,13 @@
+.. _queue_module:
+
+:mod:`retools.limiter`
+--------------------
+
+.. automodule:: retools.limiter
+
+
+Public API Classes
+~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: Limiter
+    :members: __init__, acquire_limit, release_limit

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,8 @@ retools - A Python Redis Toolset
     - `setproctitle`_ used by workers for easy worker introspection on
       the command line
     - :ref:`Rich event system <queue_events>` for extending job processing behavior
+- :mod:`Limiter <retools.limiter>`
+    - Useful for making sure that only N operations for a given process happen at the same time
 - Well Tested [1]_
     - 100% statement coverage
     - 100% condition coverage (via instrumental_)

--- a/retools/limiter.py
+++ b/retools/limiter.py
@@ -1,0 +1,99 @@
+"""Generic Limiter to ensure N parallel operations
+
+.. note::
+
+    The limiter functionality is new.
+    Please report any issues found on `the retools Github issue
+    tracker <https://github.com/bbangert/retools/issues>`_.
+
+The limiter is useful when you want to make sure that only N operations for a given process happen at the same time,
+i.e.: concurrent requests to the same domain.
+
+The limiter works by acquiring and releasing limits.
+
+Creating a limiter::
+
+    from retools.limiter import Limiter
+
+    def do_something():
+        limiter = Limiter(limit=10, prefix='my-operation')  # using default redis connection
+
+        for i in range(100):
+            if limiter.acquire_limit('operation-%d' % i):
+                execute_my_operation()
+                limiter.release_limit('operation-%d' % i)  # since we are releasing it synchronously
+                                                           # all the 100 operations will be performed with
+                                                           # one of them locked at a time
+
+Specifying a default expiration in seconds::
+
+    def do_something():
+        limiter = Limiter(limit=10, expiration_in_seconds=45)  # using default redis connection
+
+Specifying a redis connection::
+
+    def do_something():
+        limiter = Limiter(limit=10, redis=my_redis_connection)
+
+Every time you try to acquire a limit, the expired limits you previously acquired get removed from the set.
+
+This way if your process dies in the mid of its operation, the keys will eventually expire.
+"""
+
+import time
+
+from retools import global_connection
+
+
+class Limiter(object):
+    '''Configures and limits operations'''
+    def __init__(self, limit, redis=None, prefix='retools_limiter', expiration_in_seconds=10):
+        """Initializes a Limiter.
+
+        :param limit: An integer that describes the limit on the number of items
+        :param redis: A Redis instance. Defaults to the redis instance
+                      on the global_connection.
+        :param prefix: The default limit set name. Defaults to 'retools_limiter'.
+        :param expiration_in_seconds: The number in seconds that keys should be locked if not
+                            explicitly released.
+        """
+
+        self.limit = limit
+        self.redis = redis or global_connection.redis
+        self.prefix = prefix
+        self.expiration_in_seconds = expiration_in_seconds
+
+    def acquire_limit(self, key, expiration_in_seconds=None, retry=True):
+        """Tries to acquire a limit for a given key. Returns True if the limit can be acquired.
+
+        :param key: A string with the key to acquire the limit for.
+                    This key should be used when releasing.
+        :param expiration_in_seconds: The number in seconds that this key should be locked if not
+                            explicitly released. If this is not passed, the default is used.
+        :param key: Internal parameter that specifies if the operation should be retried.
+                        Defaults to True.
+        """
+
+        limit_available = self.redis.zcard(self.prefix) < self.limit
+
+        if limit_available:
+            self.__lock_limit(key, expiration_in_seconds)
+            return True
+
+        if retry:
+            self.redis.zremrangebyscore(self.prefix, '-inf', time.time())
+            return self.acquire_limit(key, expiration_in_seconds, retry=False)
+
+        return False
+
+    def release_limit(self, key):
+        """Releases a limit for a given key.
+
+        :param key: A string with the key to release the limit on.
+        """
+
+        self.redis.zrem(self.prefix, key)
+
+    def __lock_limit(self, key, expiration_in_seconds=None):
+        expiration = expiration_in_seconds or self.expiration_in_seconds
+        self.redis.zadd(self.prefix, key, time.time() + expiration)

--- a/retools/tests/test_limiter.py
+++ b/retools/tests/test_limiter.py
@@ -1,0 +1,143 @@
+# coding: utf-8
+
+import unittest
+import time
+
+import redis
+from nose.tools import eq_
+from mock import Mock
+from mock import patch
+
+from retools.limiter import Limiter
+from retools import global_connection
+
+
+class TestLimiterWithMockRedis(unittest.TestCase):
+    def test_can_create_limiter_without_prefix_and_without_connection(self):
+        limiter = Limiter(limit=10)
+
+        eq_(limiter.redis, global_connection.redis)
+        eq_(limiter.limit, 10)
+        eq_(limiter.prefix, 'retools_limiter')
+
+    def test_can_create_limiter_without_prefix(self):
+        mock_redis = Mock(spec=redis.Redis)
+
+        limiter = Limiter(limit=10, redis=mock_redis)
+
+        eq_(limiter.redis, mock_redis)
+        eq_(limiter.prefix, 'retools_limiter')
+
+    def test_can_create_limiter_with_prefix(self):
+        mock_redis = Mock(spec=redis.Redis)
+
+        limiter = Limiter(limit=10, redis=mock_redis, prefix='something')
+
+        eq_(limiter.redis, mock_redis)
+        eq_(limiter.prefix, 'something')
+
+    def test_can_create_limiter_with_expiration(self):
+        mock_redis = Mock(spec=redis.Redis)
+
+        limiter = Limiter(limit=10, redis=mock_redis, expiration_in_seconds=20)
+
+        eq_(limiter.expiration_in_seconds, 20)
+
+    def test_has_limit(self):
+        mock_time = Mock()
+        mock_time.return_value = 40.5
+
+        mock_redis = Mock(spec=redis.Redis)
+        mock_redis.zcard.return_value = 0
+
+        limiter = Limiter(limit=10, redis=mock_redis, expiration_in_seconds=20)
+
+        with patch('time.time', mock_time):
+            has_limit = limiter.acquire_limit(key='test1')
+
+        eq_(has_limit, True)
+
+        mock_redis.zadd.assert_called_once_with('retools_limiter', 'test1', 60.5)
+
+    def test_acquire_limit_after_removing_items(self):
+        mock_time = Mock()
+        mock_time.return_value = 40.5
+
+        mock_redis = Mock(spec=redis.Redis)
+        mock_redis.zcard.side_effect = [10, 8]
+
+        limiter = Limiter(limit=10, redis=mock_redis, expiration_in_seconds=20)
+
+        with patch('time.time', mock_time):
+            has_limit = limiter.acquire_limit(key='test1')
+
+        eq_(has_limit, True)
+
+        mock_redis.zadd.assert_called_once_with('retools_limiter', 'test1', 60.5)
+        mock_redis.zremrangebyscore.assert_called_once_with('retools_limiter', '-inf', 40.5)
+
+    def test_acquire_limit_fails_even_after_removing_items(self):
+        mock_time = Mock()
+        mock_time.return_value = 40.5
+
+        mock_redis = Mock(spec=redis.Redis)
+        mock_redis.zcard.side_effect = [10, 10]
+
+        limiter = Limiter(limit=10, redis=mock_redis, expiration_in_seconds=20)
+
+        with patch('time.time', mock_time):
+            has_limit = limiter.acquire_limit(key='test1')
+
+        eq_(has_limit, False)
+
+        eq_(mock_redis.zadd.called, False)
+        mock_redis.zremrangebyscore.assert_called_once_with('retools_limiter', '-inf', 40.5)
+
+    def test_release_limit(self):
+        mock_redis = Mock(spec=redis.Redis)
+
+        limiter = Limiter(limit=10, redis=mock_redis, expiration_in_seconds=20)
+
+        limiter.release_limit(key='test1')
+
+        mock_redis.zrem.assert_called_once_with('retools_limiter', 'test1')
+
+
+class TestLimiterWithActualRedis(unittest.TestCase):
+    def test_has_limit(self):
+        limiter = Limiter(prefix='test-%.6f' % time.time(), limit=2, expiration_in_seconds=400)
+
+        has_limit = limiter.acquire_limit(key='test1')
+        eq_(has_limit, True)
+
+        has_limit = limiter.acquire_limit(key='test2')
+        eq_(has_limit, True)
+
+        has_limit = limiter.acquire_limit(key='test3')
+        eq_(has_limit, False)
+
+    def test_has_limit_after_removing_items(self):
+        limiter = Limiter(prefix='test-%.6f' % time.time(), limit=2, expiration_in_seconds=400)
+
+        has_limit = limiter.acquire_limit(key='test1')
+        eq_(has_limit, True)
+
+        has_limit = limiter.acquire_limit(key='test2', expiration_in_seconds=-1)
+        eq_(has_limit, True)
+
+        has_limit = limiter.acquire_limit(key='test3')
+        eq_(has_limit, True)
+
+    def test_has_limit_after_releasing_items(self):
+        limiter = Limiter(prefix='test-%.6f' % time.time(), limit=2, expiration_in_seconds=400)
+
+        has_limit = limiter.acquire_limit(key='test1')
+        eq_(has_limit, True)
+
+        has_limit = limiter.acquire_limit(key='test2')
+        eq_(has_limit, True)
+
+        limiter.release_limit(key='test2')
+
+        has_limit = limiter.acquire_limit(key='test3')
+        eq_(has_limit, True)


### PR DESCRIPTION
I had to limit running parallel requests and thought of building my own lib. Thankfully I found retools and thought of contributing to it, instead.

The limiter class allows you to lock a specific number of items for a given operation. For instance:

```
limiter = Limiter(limit=10, prefix='parallel-requests')

for i in range(100):
    url = 'http://my.domain.com/%d.html' % i
    if limiter.acquire_limit(url):
        async_http_request(url, callback=handle_result)  # only 10 of these will get executed in parallel.
```

The app can then do something else or wait until it can acquire a limit. I hope you do consider this a generic enough construct that it should be in retools.

I tried hard to comply to the code notation and docs already in the project. If I missed something, please let me know and I'll gladly update the pull request.

The test covers 100% of the code and with both unit (mock redis) and functional (real redis) tests.
