### PR TITLE
This fixes an issue with StrictRedis and zadd.

### DIFF
--- a/retools/tests/test_util.py
+++ b/retools/tests/test_util.py
@@ -53,3 +53,25 @@ class TestContextManager(unittest.TestCase):
 class DummyClass(object):  # pragma: nocover
     def class_method(cls):
         return arg
+
+
+class TestChunks(unittest.TestCase):
+    def test_can_get_chunks(self):
+        from retools.util import chunks
+        items = [1, 2, 3, 4]
+
+        eq_(list(chunks(items, 2)), [(1, 2), (3, 4)])
+
+
+class TestFlipPairs(unittest.TestCase):
+    def test_can_flip_pairs(self):
+        from retools.util import flip_pairs
+        items = [1, 2, 3, 4]
+
+        eq_(list(flip_pairs(items)), [2, 1, 4, 3])
+
+
+#def flip_pairs(l):
+    #for x, y in chunks(l, 2):
+        #yield y
+        #yield x

--- a/retools/util.py
+++ b/retools/util.py
@@ -1,5 +1,6 @@
 """Utility functions"""
 import inspect
+from itertools import izip
 
 
 def func_namespace(func, deco_args):
@@ -50,3 +51,14 @@ def with_nested_contexts(context_managers, func, args, kwargs):
         with ctx_manager(func, *args, **kwargs):
             return with_nested_contexts(context_managers[1:],
                   func, args, kwargs)
+
+
+def chunks(iterable, n):
+    args = [iter(iterable)] * n
+    return izip(*args)
+
+
+def flip_pairs(l):
+    for x, y in chunks(l, 2):
+        yield y
+        yield x


### PR DESCRIPTION
The redis-py StrictRedis connection class adheres to the actual
redis API definition. Usually this is not an issue as redis-py
Redis class methods have the same list of arguments.

The issue arises when using ZADD, since in redis it expects
the ordered set name and the items to add with score and key in this
order.

StrictRedis uses the correct order of arguments, whereas Redis inverts
key and score. This gives users an exception if they use Retools Limiter
as it is implemented today with a StrictRedis connection.
