### PR TITLE
Lock: implement an exponential backoff on the retries with a max sleep period

### DIFF
--- a/retools/lock.py
+++ b/retools/lock.py
@@ -15,6 +15,7 @@ requires every client to have synchronized time.
 
 import time
 import uuid
+import random
 
 from retools import global_connection
 
@@ -87,7 +88,7 @@ class Lock(object):
                 return
             timeout -= 1
             if timeout >= 0:
-                time.sleep(retry_sleep)
+                time.sleep(random.uniform(0, retry_sleep))
                 retry_sleep = min(retry_sleep*2, 1)
         raise LockTimeout("Timeout while waiting for lock")
 

--- a/retools/lock.py
+++ b/retools/lock.py
@@ -80,13 +80,15 @@ class Lock(object):
         """
         self.lock_key = uuid.uuid4().hex
         timeout = self.timeout
+        retry_sleep = 0.005
         while timeout >= 0:
             if self._acquire_lua(keys=[self.key],
                                  args=[self.lock_key, self.expires]):
                 return
             timeout -= 1
             if timeout >= 0:
-                time.sleep(1)
+                time.sleep(retry_sleep)
+                retry_sleep = min(retry_sleep*2, 1)
         raise LockTimeout("Timeout while waiting for lock")
 
     def release(self):


### PR DESCRIPTION
This fixes issue #24.

Retry timeout starts at 5 milliseconds and doubles on each failed retry until it reaches a maximum of 1 second.
