### PR TITLE
Removed setup_requires nose

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(name='retools',
       zip_safe=False,
       tests_require = ['pkginfo', 'Mock>=0.8rc2', 'nose',
                        'simplejson'],
-      setup_requires=["nose"],
       install_requires=[
           "setproctitle>=1.1.2",
           "redis>=2.7.3",


### PR DESCRIPTION
I removed it because it becomes a dependency whenever installing retools in production. This would not be an issue if there was not a bug in setuptools.

If there's any packages in setup_requires, setuptools downloads it without respecting any proxy configuration. Since many production servers block outbound connections, it's desirable to remove this attribute.
