### PR TITLE
Eliminate Sphinx warnings

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2,7 +2,7 @@ API Documentation
 =================
 
 Comprehensive reference material for every public API exposed by
-:app:`retools` is available within this chapter. The API documentation is
+:py:mod:`retools` is available within this chapter. The API documentation is
 organized alphabetically by module name.
 
 .. toctree::

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,5 +10,6 @@ organized alphabetically by module name.
 
    api/cache
    api/exc
+   api/limiter
    api/lock
    api/queue

--- a/docs/api/limiter.rst
+++ b/docs/api/limiter.rst
@@ -1,7 +1,7 @@
 .. _limiter_module:
 
 :mod:`retools.limiter`
---------------------
+----------------------
 
 .. automodule:: retools.limiter
 

--- a/docs/api/limiter.rst
+++ b/docs/api/limiter.rst
@@ -1,4 +1,4 @@
-.. _queue_module:
+.. _limiter_module:
 
 :mod:`retools.limiter`
 --------------------

--- a/docs/caching.rst
+++ b/docs/caching.rst
@@ -1,6 +1,0 @@
-.. _caching:
-
-Caching Data
-============
-
-`retools` implements 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -120,7 +120,7 @@ html_theme = 'default'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/retools/queue.py
+++ b/retools/queue.py
@@ -68,7 +68,7 @@ Event functions have different call semantics, the following is a list of how
 the event functions will be called:
 
 * **job_prerun**: (job=job_instance)
-* **job_wrapper**: (job_function, job_instance, **job_keyword_arguments)
+* **job_wrapper**: (job_function, job_instance, \*\*job_keyword_arguments)
 * **job_postrun**: (job=job_instance, result=job_function_result)
 * **job_failure**: (job=job_instance, exc=job_exception)
 


### PR DESCRIPTION
A bunch of cleanup to prevent Sphinx warnings:
##### Before:

```
$ rm -rf _build ; make html
sphinx-build -b html -d _build/doctrees   . _build/html
Making output directory...
Running Sphinx v1.2.3
loading pickled environment... not yet created
building [html]: targets for 9 source files that are out of date
updating environment: 9 added, 0 changed, 0 removed
reading sources... [100%] index
/Users/marca/dev/git-repos/retools/docs/api.rst:4: ERROR: Unknown interpreted text role "app".
/Users/marca/dev/git-repos/retools/docs/api/limiter.rst:4: WARNING: Title underline too short.

:mod:`retools.limiter`
--------------------
/Users/marca/dev/git-repos/retools/retools/queue.py:docstring of retools.queue:71: WARNING: Inline strong start-string without end-string.
/Users/marca/dev/git-repos/retools/docs/api/queue.rst:4: WARNING: duplicate label queue_module, other instance in /Users/marca/dev/git-repos/retools/docs/api/limiter.rst
looking for now-outdated files... none found
pickling environment... done
checking consistency... /Users/marca/dev/git-repos/retools/docs/api/limiter.rst:: WARNING: document isn't included in any toctree
/Users/marca/dev/git-repos/retools/docs/caching.rst:: WARNING: document isn't included in any toctree
done
preparing documents... done
writing output... [100%] index
writing additional files... (5 module code pages) _modules/index genindex py-modindex search
copying static files... WARNING: html_static_path entry u'/Users/marca/dev/git-repos/retools/docs/_static' does not exist
done
copying extra files... done
dumping search index... done
dumping object inventory... done
build succeeded, 7 warnings.

Build finished. The HTML pages are in _build/html.
```
##### After:

```
$ rm -rf _build ; make html
sphinx-build -b html -d _build/doctrees   . _build/html
Making output directory...
Running Sphinx v1.2.3
loading pickled environment... not yet created
building [html]: targets for 8 source files that are out of date
updating environment: 8 added, 0 changed, 0 removed
reading sources... [100%] index
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] index
writing additional files... (5 module code pages) _modules/index genindex py-modindex search
copying static files... done
copying extra files... done
dumping search index... done
dumping object inventory... done
build succeeded.

Build finished. The HTML pages are in _build/html.
```
